### PR TITLE
gradle: Make Java compilation task depend on native build task

### DIFF
--- a/android-launch/app/build.gradle
+++ b/android-launch/app/build.gradle
@@ -44,7 +44,10 @@ android {
     }
 }
 
-tasks.getByName('sourceSets').dependsOn 'externalNativeBuildDebug'
+afterEvaluate {
+    compileDebugJavaWithJavac.dependsOn 'externalNativeBuildDebug'
+    compileReleaseJavaWithJavac.dependsOn 'externalNativeBuildRelease'
+}
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])


### PR DESCRIPTION
'sourceSets' doesn't seem to be run in the standard build process any
more, and this dependency seems more accurate.